### PR TITLE
add Makefile for basic checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: clean
+all: format lint check test
+
+.PHONY: format
+format:
+	cargo fmt
+
+.PHONY: lint
+lint:
+	cargo clippy
+
+.PHONY: check
+check:
+	cargo check
+	cargo check --examples
+
+.PHONY: test
+test:
+	cargo test


### PR DESCRIPTION
Add a Makefile that will run all the basic code checks via Cargo. Cargo
is needed as a dependency.

Signed-off-by: Petr Horacek <phoracek@redhat.com>